### PR TITLE
Fix warning

### DIFF
--- a/src/elapsed.rs
+++ b/src/elapsed.rs
@@ -49,7 +49,7 @@ mod tests {
         struct Case {
             secs: u64,
             expected: Elapsed,
-        };
+        }
         let cases = [
             Case {
                 secs: 30,


### PR DESCRIPTION
Delete redundant semicolon which caused warning
```
warning: unnecessary trailing semicolon
  --> src/elapsed.rs:52:10
   |
52 |         };
   |          ^ help: remove this semicolon
   |
   = note: `#[warn(redundant_semicolons)]` on by default

warning: `textris` (lib test) generated 1 warning
```