### PR TITLE
Bg instead of fg

### DIFF
--- a/src/block.rs
+++ b/src/block.rs
@@ -16,12 +16,17 @@ impl Block {
 
 impl fmt::Display for Block {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let bg = if self.chr == 'X' { Color::white() } else { self.color };
+        let fg = if self.chr == 'X' { Color::black() } else { Color::white() };
+
         write!(
             f,
-            "{}{}{}",
-            color::Fg(self.color),
+            "{}{}{}{}{}",
+            color::Fg(fg),
+            color::Bg(bg),
             self.chr,
-            color::Fg(color::Reset)
+            color::Fg(color::Reset),
+            color::Bg(Color::black()),
         )
     }
 }

--- a/src/game.rs
+++ b/src/game.rs
@@ -46,6 +46,7 @@ fn make_help_modal(inputs: &Inputs) -> Modal {
 fn key_name(key: Key) -> String {
     match key {
         Key::Char(chr) => chr.to_string(),
+        Key::Up => "↑".to_string(),
         Key::Left => "←".to_string(),
         Key::Right => "→".to_string(),
         Key::Down => "↓".to_string(),

--- a/src/inputs/keys.rs
+++ b/src/inputs/keys.rs
@@ -22,6 +22,7 @@ impl KeyConverter {
         use super::Order::*;
         match self {
             KeyConverter::Normal => hash_map! {
+                Key::Up => Rotate(RotateDir::Clockwise),
                 Key::Left => Move(Dir::Left),
                 Key::Right => Move(Dir::Right),
                 Key::Down => Move(Dir::Down),


### PR DESCRIPTION
- Use background colours instead of foreground (I think it’s clearer to see).
- Enable up arrow key to rotate clockwise.